### PR TITLE
Fix data corruption with binary data uri

### DIFF
--- a/Sources/DataURI/Parser.swift
+++ b/Sources/DataURI/Parser.swift
@@ -41,10 +41,9 @@ extension DataURIParser {
         }
         
         if typeMetadata == "base64".bytes,
-            let decodedData = Data(base64Encoded: data.convertToData()),
-            let dataString = String(data: decodedData, encoding: .utf8)
+            let decodedData = Data(base64Encoded: data.convertToData())
         {
-            data = dataString.bytes
+            data = Array(decodedData)
         }
 
         return (data, type, typeMetadata)

--- a/Tests/DataURITests/DataURITests.swift
+++ b/Tests/DataURITests/DataURITests.swift
@@ -34,6 +34,16 @@ class DataURITests: XCTestCase {
         XCTAssertEqual(meta?.makeString(), "base64")
     }
     
+    func testBase64Binary() {
+        let (data, type, meta) = try! DataURIParser.parse(
+            uri: "data:text/plain;base64,AAECA3Rlc3QK"
+        )
+        
+        XCTAssertEqual(data, [0, 1, 2, 3, 116, 101, 115, 116, 10])
+        XCTAssertEqual(type.makeString(), "text/plain")
+        XCTAssertEqual(meta?.makeString(), "base64")
+    }
+    
     func testHTMLText() {
         let (data, type, meta) = try! DataURIParser.parse(
             uri: "data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E"


### PR DESCRIPTION
This PR Fixes #12 

Removes the intermediary utf-8 string conversion and keeps output in binary form.